### PR TITLE
refactor(simple-memory): 对titleMsg显示进行优化

### DIFF
--- a/src/style/simpleMemory.css
+++ b/src/style/simpleMemory.css
@@ -532,6 +532,22 @@ p.article-info-text > .postMeta br {
 /*    color: #ccc*/
 /*}*/
 
+.sidebar-title-msg {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 195px;
+}
+
+.sidebar-title-msg:hover {
+    cursor: pointer;
+    width: 195px;
+    white-space: unset;
+    overflow: auto;
+    text-overflow: unset;
+    animation: none;
+}
+
 #sb_widget_my_zzk {
     width: 100%;
     text-align: center


### PR DESCRIPTION
内容过多时进行隐藏，鼠标移动过去hover显示

![image](https://user-images.githubusercontent.com/36377605/232241923-40fc53b5-e965-4243-a4b5-ffc355dccdb4.png)
