### PR TITLE
fix(iconfont): extend iconfont

### DIFF
--- a/src/style/fonticon.css
+++ b/src/style/fonticon.css
@@ -1,12 +1,12 @@
 @font-face {
-    font-family: "simple-memory-iconfont"; /* Project id 543384 */
+    font-family: 'simple-memory-iconfont'; /* Project id 543384 */
     src: url('//at.alicdn.com/t/c/font_543384_0v1w10gd4o1i.woff2?t=1684910988520') format('woff2'),
-    url('//at.alicdn.com/t/c/font_543384_0v1w10gd4o1i.woff?t=1684910988520') format('woff'),
-    url('//at.alicdn.com/t/c/font_543384_0v1w10gd4o1i.ttf?t=1684910988520') format('truetype');
+        url('//at.alicdn.com/t/c/font_543384_0v1w10gd4o1i.woff?t=1684910988520') format('woff'),
+        url('//at.alicdn.com/t/c/font_543384_0v1w10gd4o1i.ttf?t=1684910988520') format('truetype');
 }
 
 .simple-memory-iconfont {
-    font-family: "simple-memory-iconfont" !important;
+    font-family: 'simple-memory-iconfont', 'iconfont' !important;
     font-size: 16px;
     font-style: normal;
     -webkit-font-smoothing: antialiased;
@@ -23,1153 +23,1153 @@
 }
 
 .simple-memory-icon-baidu:before {
-    content: "\e68c";
+    content: '\e68c';
 }
 
 .simple-memory-icon-baidu0:before {
-    content: "\e68f";
+    content: '\e68f';
 }
 
 .simple-memory-icon-baidutieba:before {
-    content: "\e694";
+    content: '\e694';
 }
 
 .simple-memory-icon-behance:before {
-    content: "\e695";
+    content: '\e695';
 }
 
 .simple-memory-icon-behance0:before {
-    content: "\e697";
+    content: '\e697';
 }
 
 .simple-memory-icon-diandian:before {
-    content: "\e69b";
+    content: '\e69b';
 }
 
 .simple-memory-icon-douban:before {
-    content: "\e69c";
+    content: '\e69c';
 }
 
 .simple-memory-icon-facebook:before {
-    content: "\e69d";
+    content: '\e69d';
 }
 
 .simple-memory-icon-facebook0:before {
-    content: "\e69e";
+    content: '\e69e';
 }
 
 .simple-memory-icon-flicker:before {
-    content: "\e69f";
+    content: '\e69f';
 }
 
 .simple-memory-icon-fuzhilianjie:before {
-    content: "\e6a0";
+    content: '\e6a0';
 }
 
 .simple-memory-icon-google:before {
-    content: "\e6a1";
+    content: '\e6a1';
 }
 
 .simple-memory-icon-google0:before {
-    content: "\e6a2";
+    content: '\e6a2';
 }
 
 .simple-memory-icon-kaixinwang:before {
-    content: "\e6a3";
+    content: '\e6a3';
 }
 
 .simple-memory-icon-kaixinwang0:before {
-    content: "\e6a4";
+    content: '\e6a4';
 }
 
 .simple-memory-icon-kongjian:before {
-    content: "\e6a5";
+    content: '\e6a5';
 }
 
 .simple-memory-icon-kongjian0:before {
-    content: "\e6a6";
+    content: '\e6a6';
 }
 
 .simple-memory-icon-linkedin:before {
-    content: "\e6a7";
+    content: '\e6a7';
 }
 
 .simple-memory-icon-linkedin0:before {
-    content: "\e6aa";
+    content: '\e6aa';
 }
 
 .simple-memory-icon-meilishuo:before {
-    content: "\e6ab";
+    content: '\e6ab';
 }
 
 .simple-memory-icon-pengyouquan:before {
-    content: "\e6ad";
+    content: '\e6ad';
 }
 
 .simple-memory-icon-pengyouquan0:before {
-    content: "\e6af";
+    content: '\e6af';
 }
 
 .simple-memory-icon-pengyouquanyin:before {
-    content: "\e6b0";
+    content: '\e6b0';
 }
 
 .simple-memory-icon-pengyouquanyin0:before {
-    content: "\e6b1";
+    content: '\e6b1';
 }
 
 .simple-memory-icon-pinterest:before {
-    content: "\e6b5";
+    content: '\e6b5';
 }
 
 .simple-memory-icon-pinterest0:before {
-    content: "\e6b6";
+    content: '\e6b6';
 }
 
 .simple-memory-icon-qq:before {
-    content: "\e6b7";
+    content: '\e6b7';
 }
 
 .simple-memory-icon-qq0:before {
-    content: "\e6b8";
+    content: '\e6b8';
 }
 
 .simple-memory-icon-renren:before {
-    content: "\e6b9";
+    content: '\e6b9';
 }
 
 .simple-memory-icon-renren0:before {
-    content: "\e6ba";
+    content: '\e6ba';
 }
 
 .simple-memory-icon-sina:before {
-    content: "\e6bb";
+    content: '\e6bb';
 }
 
 .simple-memory-icon-sina0:before {
-    content: "\e6bc";
+    content: '\e6bc';
 }
 
 .simple-memory-icon-taobao:before {
-    content: "\e6bd";
+    content: '\e6bd';
 }
 
 .simple-memory-icon-taobaoyin:before {
-    content: "\e6be";
+    content: '\e6be';
 }
 
 .simple-memory-icon-tianya:before {
-    content: "\e6bf";
+    content: '\e6bf';
 }
 
 .simple-memory-icon-tianya0:before {
-    content: "\e6c0";
+    content: '\e6c0';
 }
 
 .simple-memory-icon-twitter:before {
-    content: "\e6c1";
+    content: '\e6c1';
 }
 
 .simple-memory-icon-twitter0:before {
-    content: "\e6c2";
+    content: '\e6c2';
 }
 
 .simple-memory-icon-wangwang:before {
-    content: "\e6c3";
+    content: '\e6c3';
 }
 
 .simple-memory-icon-wangyi:before {
-    content: "\e6c5";
+    content: '\e6c5';
 }
 
 .simple-memory-icon-wangyi0:before {
-    content: "\e6c7";
+    content: '\e6c7';
 }
 
 .simple-memory-icon-weibo:before {
-    content: "\e6c8";
+    content: '\e6c8';
 }
 
 .simple-memory-icon-weiboo:before {
-    content: "\e6ca";
+    content: '\e6ca';
 }
 
 .simple-memory-icon-weixin:before {
-    content: "\e6cb";
+    content: '\e6cb';
 }
 
 .simple-memory-icon-weixin0:before {
-    content: "\e6cc";
+    content: '\e6cc';
 }
 
 .simple-memory-icon-xin:before {
-    content: "\e6cd";
+    content: '\e6cd';
 }
 
 .simple-memory-icon-yixin:before {
-    content: "\e6ce";
+    content: '\e6ce';
 }
 
 .simple-memory-icon-yixin0:before {
-    content: "\e6cf";
+    content: '\e6cf';
 }
 
 .simple-memory-icon-youjian:before {
-    content: "\e6d0";
+    content: '\e6d0';
 }
 
 .simple-memory-icon-youjian0:before {
-    content: "\e6d1";
+    content: '\e6d1';
 }
 
 .simple-memory-icon-zhifubao:before {
-    content: "\e6d3";
+    content: '\e6d3';
 }
 
 .simple-memory-icon-zhifubao0:before {
-    content: "\e6d4";
+    content: '\e6d4';
 }
 
 .simple-memory-icon-zhihu:before {
-    content: "\e6d5";
+    content: '\e6d5';
 }
 
 .simple-memory-icon-tieba0:before {
-    content: "\e6d8";
+    content: '\e6d8';
 }
 
 .simple-memory-icon-zhihu0:before {
-    content: "\e709";
+    content: '\e709';
 }
 
 .simple-memory-icon-douban0:before {
-    content: "\e70a";
+    content: '\e70a';
 }
 
 .simple-memory-icon-evernote-fill:before {
-    content: "\e7ad";
+    content: '\e7ad';
 }
 
 .simple-memory-icon-evernote-line:before {
-    content: "\e7ae";
+    content: '\e7ae';
 }
 
 .simple-memory-icon-reddit-line:before {
-    content: "\e7af";
+    content: '\e7af';
 }
 
 .simple-memory-icon-dingding-fill:before {
-    content: "\e7b2";
+    content: '\e7b2';
 }
 
 .simple-memory-icon-dingding-line:before {
-    content: "\e7b3";
+    content: '\e7b3';
 }
 
 .simple-memory-icon-github-fill:before {
-    content: "\e7b5";
+    content: '\e7b5';
 }
 
 .simple-memory-icon-paypal-fill:before {
-    content: "\e7bb";
+    content: '\e7bb';
 }
 
 .simple-memory-icon-windows-fill:before {
-    content: "\e7bd";
+    content: '\e7bd';
 }
 
 .simple-memory-icon-leimupinleifenleileibie2:before {
-    content: "\e7f8";
+    content: '\e7f8';
 }
 
 .simple-memory-icon-fenleicur:before {
-    content: "\e652";
+    content: '\e652';
 }
 
 .simple-memory-icon-fenlei201:before {
-    content: "\e64f";
+    content: '\e64f';
 }
 
 .simple-memory-icon-fenlei:before {
-    content: "\e650";
+    content: '\e650';
 }
 
 .simple-memory-icon-weixuanzhongyuanquan:before {
-    content: "\e64c";
+    content: '\e64c';
 }
 
 .simple-memory-icon-yuanxingweixuanzhong:before {
-    content: "\e72f";
+    content: '\e72f';
 }
 
 .simple-memory-icon-yuan:before {
-    content: "\e64e";
+    content: '\e64e';
 }
 
 .simple-memory-icon-yuan1:before {
-    content: "\edf8";
+    content: '\edf8';
 }
 
 .simple-memory-icon-arrow-down:before {
-    content: "\e63b";
+    content: '\e63b';
 }
 
 .simple-memory-icon-arrow-right:before {
-    content: "\e648";
+    content: '\e648';
 }
 
 .simple-memory-icon-xiala:before {
-    content: "\e649";
+    content: '\e649';
 }
 
 .simple-memory-icon-close:before {
-    content: "\e6ac";
+    content: '\e6ac';
 }
 
 .simple-memory-icon-close-mini:before {
-    content: "\e644";
+    content: '\e644';
 }
 
 .simple-memory-icon-close1:before {
-    content: "\e645";
+    content: '\e645';
 }
 
 .simple-memory-icon-close2:before {
-    content: "\e647";
+    content: '\e647';
 }
 
 .simple-memory-icon-close3:before {
-    content: "\e6dc";
+    content: '\e6dc';
 }
 
 .simple-memory-icon-guangbo:before {
-    content: "\e6ae";
+    content: '\e6ae';
 }
 
 .simple-memory-icon-sousuo1:before {
-    content: "\e63e";
+    content: '\e63e';
 }
 
 .simple-memory-icon-sousuo2:before {
-    content: "\e8b9";
+    content: '\e8b9';
 }
 
 .simple-memory-icon-sousuo3:before {
-    content: "\e640";
+    content: '\e640';
 }
 
 .simple-memory-icon-home:before {
-    content: "\e7a5";
+    content: '\e7a5';
 }
 
 .simple-memory-icon-home1:before {
-    content: "\e65c";
+    content: '\e65c';
 }
 
 .simple-memory-icon-home2:before {
-    content: "\e643";
+    content: '\e643';
 }
 
 .simple-memory-icon-home4:before {
-    content: "\e68b";
+    content: '\e68b';
 }
 
 .simple-memory-icon-geren1:before {
-    content: "\e63c";
+    content: '\e63c';
 }
 
 .simple-memory-icon-jindu:before {
-    content: "\e634";
+    content: '\e634';
 }
 
 .simple-memory-icon-book:before {
-    content: "\e635";
+    content: '\e635';
 }
 
 .simple-memory-icon-jindu1:before {
-    content: "\e637";
+    content: '\e637';
 }
 
 .simple-memory-icon-schedule:before {
-    content: "\e638";
+    content: '\e638';
 }
 
 .simple-memory-icon-jindu2:before {
-    content: "\e799";
+    content: '\e799';
 }
 
 .simple-memory-icon-jindu3:before {
-    content: "\e639";
+    content: '\e639';
 }
 
 .simple-memory-icon-7777:before {
-    content: "\e63a";
+    content: '\e63a';
 }
 
 .simple-memory-icon-icon_yuedushijian:before {
-    content: "\e66b";
+    content: '\e66b';
 }
 
 .simple-memory-icon-pingjixingquanxing:before {
-    content: "\e62a";
+    content: '\e62a';
 }
 
 .simple-memory-icon-pingjixingxiantiao:before {
-    content: "\e632";
+    content: '\e632';
 }
 
 .simple-memory-icon-pingjixingbanxing:before {
-    content: "\e633";
+    content: '\e633';
 }
 
 .simple-memory-icon-wenzi2:before {
-    content: "\e69a";
+    content: '\e69a';
 }
 
 .simple-memory-icon-wenzi3:before {
-    content: "\e629";
+    content: '\e629';
 }
 
 .simple-memory-icon-wenzi4:before {
-    content: "\e692";
+    content: '\e692';
 }
 
 .simple-memory-icon-wenzi:before {
-    content: "\e63f";
+    content: '\e63f';
 }
 
 .simple-memory-icon-shangwutubiao-:before {
-    content: "\e641";
+    content: '\e641';
 }
 
 .simple-memory-icon-Font_Linear:before {
-    content: "\e67e";
+    content: '\e67e';
 }
 
 .simple-memory-icon-M_tupianzhuanwenzi:before {
-    content: "\e759";
+    content: '\e759';
 }
 
 .simple-memory-icon-shezhi2:before {
-    content: "\e72d";
+    content: '\e72d';
 }
 
 .simple-memory-icon-shezhi3:before {
-    content: "\e696";
+    content: '\e696';
 }
 
 .simple-memory-icon-shezhi4:before {
-    content: "\e631";
+    content: '\e631';
 }
 
 .simple-memory-icon-ico:before {
-    content: "\e646";
+    content: '\e646';
 }
 
 .simple-memory-icon-erweima4:before {
-    content: "\e66e";
+    content: '\e66e';
 }
 
 .simple-memory-icon-logo:before {
-    content: "\e620";
+    content: '\e620';
 }
 
 .simple-memory-icon-miaojie1029logo:before {
-    content: "\e693";
+    content: '\e693';
 }
 
 .simple-memory-icon-csdn:before {
-    content: "\e621";
+    content: '\e621';
 }
 
 .simple-memory-icon-logo1:before {
-    content: "\e63d";
+    content: '\e63d';
 }
 
 .simple-memory-icon-bilibili:before {
-    content: "\e6b4";
+    content: '\e6b4';
 }
 
 .simple-memory-icon-logo-bitcoin:before {
-    content: "\e6c4";
+    content: '\e6c4';
 }
 
 .simple-memory-icon-logo-css:before {
-    content: "\e6c6";
+    content: '\e6c6';
 }
 
 .simple-memory-icon-logo-npm:before {
-    content: "\e6d2";
+    content: '\e6d2';
 }
 
 .simple-memory-icon-logo-skype:before {
-    content: "\e6d7";
+    content: '\e6d7';
 }
 
 .simple-memory-icon-budaidise:before {
-    content: "\e75b";
+    content: '\e75b';
 }
 
 .simple-memory-icon-logo-tux:before {
-    content: "\e7b4";
+    content: '\e7b4';
 }
 
 .simple-memory-icon-logo-twitter:before {
-    content: "\e7ab";
+    content: '\e7ab';
 }
 
 .simple-memory-icon-logo-twitch:before {
-    content: "\e7b0";
+    content: '\e7b0';
 }
 
 .simple-memory-icon-logo-pinterest:before {
-    content: "\e6f8";
+    content: '\e6f8';
 }
 
 .simple-memory-icon-logo-tumblr:before {
-    content: "\e6fa";
+    content: '\e6fa';
 }
 
 .simple-memory-icon-logo-reddit:before {
-    content: "\e6fd";
+    content: '\e6fd';
 }
 
 .simple-memory-icon-logo-steam:before {
-    content: "\e6fe";
+    content: '\e6fe';
 }
 
 .simple-memory-icon-Ggooglelogo:before {
-    content: "\e6b2";
+    content: '\e6b2';
 }
 
 .simple-memory-icon-logo-closed-captioning:before {
-    content: "\e724";
+    content: '\e724';
 }
 
 .simple-memory-icon-logo-linkedin:before {
-    content: "\e72a";
+    content: '\e72a';
 }
 
 .simple-memory-icon-logo-xbox:before {
-    content: "\e73a";
+    content: '\e73a';
 }
 
 .simple-memory-icon-logo-apple:before {
-    content: "\e64d";
+    content: '\e64d';
 }
 
 .simple-memory-icon-social-_logo-blogger:before {
-    content: "\e678";
+    content: '\e678';
 }
 
 .simple-memory-icon-social-_logo-behance:before {
-    content: "\e679";
+    content: '\e679';
 }
 
 .simple-memory-icon-social-_logo-px:before {
-    content: "\e67a";
+    content: '\e67a';
 }
 
 .simple-memory-icon-social-_logo-dropbox:before {
-    content: "\e67b";
+    content: '\e67b';
 }
 
 .simple-memory-icon-social-_logo-creative-market:before {
-    content: "\e67c";
+    content: '\e67c';
 }
 
 .simple-memory-icon-social-_logo-codepen:before {
-    content: "\e67d";
+    content: '\e67d';
 }
 
 .simple-memory-icon-social-_logo-evernote:before {
-    content: "\e67f";
+    content: '\e67f';
 }
 
 .simple-memory-icon-social-_logo-instagram:before {
-    content: "\e680";
+    content: '\e680';
 }
 
 .simple-memory-icon-social-_logo-google-plus:before {
-    content: "\e681";
+    content: '\e681';
 }
 
 .simple-memory-icon-social-_logo-paypal:before {
-    content: "\e682";
+    content: '\e682';
 }
 
 .simple-memory-icon-social-_logo-reddit:before {
-    content: "\e683";
+    content: '\e683';
 }
 
 .simple-memory-icon-social-_logo-linkedin:before {
-    content: "\e684";
+    content: '\e684';
 }
 
 .simple-memory-icon-social-_logo-deviantart:before {
-    content: "\e685";
+    content: '\e685';
 }
 
 .simple-memory-icon-social-_logo-rss:before {
-    content: "\e686";
+    content: '\e686';
 }
 
 .simple-memory-icon-social-_logo-skype:before {
-    content: "\e687";
+    content: '\e687';
 }
 
 .simple-memory-icon-social-_logo-soundcloud:before {
-    content: "\e688";
+    content: '\e688';
 }
 
 .simple-memory-icon-social-_logo-tumblr:before {
-    content: "\e689";
+    content: '\e689';
 }
 
 .simple-memory-icon-social-_logo-slack:before {
-    content: "\e68a";
+    content: '\e68a';
 }
 
 .simple-memory-icon-social-_logo-youtube:before {
-    content: "\e68d";
+    content: '\e68d';
 }
 
 .simple-memory-icon-social-_logo-wordpress:before {
-    content: "\e68e";
+    content: '\e68e';
 }
 
 .simple-memory-icon-logo-markdown:before {
-    content: "\e604";
+    content: '\e604';
 }
 
 .simple-memory-icon-logo-python:before {
-    content: "\e607";
+    content: '\e607';
 }
 
 .simple-memory-icon-logo-nodejs:before {
-    content: "\e627";
+    content: '\e627';
 }
 
 .simple-memory-icon-logo-facebook:before {
-    content: "\e8f1";
+    content: '\e8f1';
 }
 
 .simple-memory-icon-logo-octocat:before {
-    content: "\e8f3";
+    content: '\e8f3';
 }
 
 .simple-memory-icon-logo_ie:before {
-    content: "\e62b";
+    content: '\e62b';
 }
 
 .simple-memory-icon-logo_QQ:before {
-    content: "\e62d";
+    content: '\e62d';
 }
 
 .simple-memory-icon-logo_gitlab:before {
-    content: "\e62e";
+    content: '\e62e';
 }
 
 .simple-memory-icon-logo_dingding:before {
-    content: "\e62f";
+    content: '\e62f';
 }
 
 .simple-memory-icon-logo_weibo_circle:before {
-    content: "\e630";
+    content: '\e630';
 }
 
 .simple-memory-icon-sichuantianfuyinhanglogo:before {
-    content: "\e6a9";
+    content: '\e6a9';
 }
 
 .simple-memory-icon-logo-wechat:before {
-    content: "\e677";
+    content: '\e677';
 }
 
 .simple-memory-icon-blog-solid:before {
-    content: "\e698";
+    content: '\e698';
 }
 
 .simple-memory-icon-gitee1:before {
-    content: "\e61f";
+    content: '\e61f';
 }
 
 .simple-memory-icon-woguanzhudepinpai:before {
-    content: "\e613";
+    content: '\e613';
 }
 
 .simple-memory-icon-shoucangxuanzhong:before {
-    content: "\e615";
+    content: '\e615';
 }
 
 .simple-memory-icon-qinmifu:before {
-    content: "\e61c";
+    content: '\e61c';
 }
 
 .simple-memory-icon-pengyoufill:before {
-    content: "\e746";
+    content: '\e746';
 }
 
 .simple-memory-icon-shoucang:before {
-    content: "\e86d";
+    content: '\e86d';
 }
 
 .simple-memory-icon-xihuan:before {
-    content: "\e86f";
+    content: '\e86f';
 }
 
 .simple-memory-icon-cnblogs:before {
-    content: "\e61d";
+    content: '\e61d';
 }
 
 .simple-memory-icon-tengxunyun:before {
-    content: "\e61e";
+    content: '\e61e';
 }
 
 .simple-memory-icon-renzhenghuizhang:before {
-    content: "\e673";
+    content: '\e673';
 }
 
 .simple-memory-icon-qianzishenhe:before {
-    content: "\e6b3";
+    content: '\e6b3';
 }
 
 .simple-memory-icon-zhifeiji:before {
-    content: "\e7d5";
+    content: '\e7d5';
 }
 
 .simple-memory-icon-group_fill:before {
-    content: "\e6ff";
+    content: '\e6ff';
 }
 
 .simple-memory-icon-setup_fill:before {
-    content: "\e728";
+    content: '\e728';
 }
 
 .simple-memory-icon-gitee:before {
-    content: "\e6d6";
+    content: '\e6d6';
 }
 
 .simple-memory-icon-gitlab:before {
-    content: "\e779";
+    content: '\e779';
 }
 
 .simple-memory-icon-github:before {
-    content: "\e690";
+    content: '\e690';
 }
 
 .simple-memory-icon-blogs:before {
-    content: "\e642";
+    content: '\e642';
 }
 
 .simple-memory-icon-dazhongicon04:before {
-    content: "\e624";
+    content: '\e624';
 }
 
 .simple-memory-icon-pinglun:before {
-    content: "\e605";
+    content: '\e605';
 }
 
 .simple-memory-icon-pinglun1:before {
-    content: "\e62c";
+    content: '\e62c';
 }
 
 .simple-memory-icon-pinglun2:before {
-    content: "\e6a8";
+    content: '\e6a8';
 }
 
 .simple-memory-icon-pinglun3:before {
-    content: "\e608";
+    content: '\e608';
 }
 
 .simple-memory-icon-pinglun4:before {
-    content: "\e60e";
+    content: '\e60e';
 }
 
 .simple-memory-icon-huaban:before {
-    content: "\e603";
+    content: '\e603';
 }
 
 .simple-memory-icon-mulu:before {
-    content: "\e60c";
+    content: '\e60c';
 }
 
 .simple-memory-icon-mulu5:before {
-    content: "\e60d";
+    content: '\e60d';
 }
 
 .simple-memory-icon-gongzhonghao:before {
-    content: "\e60f";
+    content: '\e60f';
 }
 
 .simple-memory-icon-wodashangderen:before {
-    content: "\e64b";
+    content: '\e64b';
 }
 
 .simple-memory-icon-gongzhonghao_:before {
-    content: "\e609";
+    content: '\e609';
 }
 
 .simple-memory-icon-gongzhonghaoerweima:before {
-    content: "\e623";
+    content: '\e623';
 }
 
 .simple-memory-icon-gongzhonghao1:before {
-    content: "\e619";
+    content: '\e619';
 }
 
 .simple-memory-icon-dashang1:before {
-    content: "\e691";
+    content: '\e691';
 }
 
 .simple-memory-icon-dashang2:before {
-    content: "\e602";
+    content: '\e602';
 }
 
 .simple-memory-icon-huodongguanli-dashanggongneng:before {
-    content: "\e6c9";
+    content: '\e6c9';
 }
 
 .simple-memory-icon-gongzhonghao2:before {
-    content: "\e819";
+    content: '\e819';
 }
 
 .simple-memory-icon-bad:before {
-    content: "\e745";
+    content: '\e745';
 }
 
 .simple-memory-icon-good:before {
-    content: "\e753";
+    content: '\e753';
 }
 
 .simple-memory-icon-hot:before {
-    content: "\e754";
+    content: '\e754';
 }
 
 .simple-memory-icon-xl:before {
-    content: "\e60b";
+    content: '\e60b';
 }
 
 .simple-memory-icon-aixin:before {
-    content: "\e612";
+    content: '\e612';
 }
 
 .simple-memory-icon-weibiaoti22:before {
-    content: "\e64a";
+    content: '\e64a';
 }
 
 .simple-memory-icon-QRcode:before {
-    content: "\e708";
+    content: '\e708';
 }
 
 .simple-memory-icon-menudots:before {
-    content: "\e65a";
+    content: '\e65a';
 }
 
 .simple-memory-icon-shang:before {
-    content: "\e611";
+    content: '\e611';
 }
 
 .simple-memory-icon-xuanshang:before {
-    content: "\e61a";
+    content: '\e61a';
 }
 
 .simple-memory-icon-interactive:before {
-    content: "\e705";
+    content: '\e705';
 }
 
 .simple-memory-icon-browse:before {
-    content: "\e6e6";
+    content: '\e6e6';
 }
 
 .simple-memory-icon-time1:before {
-    content: "\e736";
+    content: '\e736';
 }
 
 .simple-memory-icon-right:before {
-    content: "\e7f6";
+    content: '\e7f6';
 }
 
 .simple-memory-icon-pinglunzu:before {
-    content: "\e766";
+    content: '\e766';
 }
 
 .simple-memory-icon-select:before {
-    content: "\e813";
+    content: '\e813';
 }
 
 .simple-memory-icon-xiala-copy:before {
-    content: "\e625";
+    content: '\e625';
 }
 
 .simple-memory-icon-xiala-copy-copy:before {
-    content: "\e626";
+    content: '\e626';
 }
 
 .simple-memory-icon-zhtn:before {
-    content: "\e765";
+    content: '\e765';
 }
 
 .simple-memory-icon-addressbook_fill:before {
-    content: "\e6e2";
+    content: '\e6e2';
 }
 
 .simple-memory-icon-barrage_fill:before {
-    content: "\e6e3";
+    content: '\e6e3';
 }
 
 .simple-memory-icon-brush_fill:before {
-    content: "\e6e5";
+    content: '\e6e5';
 }
 
 .simple-memory-icon-computer_fill:before {
-    content: "\e6eb";
+    content: '\e6eb';
 }
 
 .simple-memory-icon-createtask_fill:before {
-    content: "\e6ee";
+    content: '\e6ee';
 }
 
 .simple-memory-icon-dynamic_fill:before {
-    content: "\e6f4";
+    content: '\e6f4';
 }
 
 .simple-memory-icon-emoji_fill:before {
-    content: "\e6f6";
+    content: '\e6f6';
 }
 
 .simple-memory-icon-enterinto_fill:before {
-    content: "\e6f9";
+    content: '\e6f9';
 }
 
 .simple-memory-icon-flag_fill:before {
-    content: "\e6fb";
+    content: '\e6fb';
 }
 
 .simple-memory-icon-flashlight_fill:before {
-    content: "\e6fc";
+    content: '\e6fc';
 }
 
 .simple-memory-icon-headlines_fill:before {
-    content: "\e700";
+    content: '\e700';
 }
 
 .simple-memory-icon-homepage_fill:before {
-    content: "\e702";
+    content: '\e702';
 }
 
 .simple-memory-icon-interactive_fill:before {
-    content: "\e704";
+    content: '\e704';
 }
 
 .simple-memory-icon-mine_fill:before {
-    content: "\e70f";
+    content: '\e70f';
 }
 
 .simple-memory-icon-picture_fill:before {
-    content: "\e716";
+    content: '\e716';
 }
 
 .simple-memory-icon-play_fill:before {
-    content: "\e717";
+    content: '\e717';
 }
 
 .simple-memory-icon-prompt_fill:before {
-    content: "\e71b";
+    content: '\e71b';
 }
 
 .simple-memory-icon-redpacket_fill:before {
-    content: "\e71d";
+    content: '\e71d';
 }
 
 .simple-memory-icon-remind_fill:before {
-    content: "\e71f";
+    content: '\e71f';
 }
 
 .simple-memory-icon-smallscreen_fill:before {
-    content: "\e72b";
+    content: '\e72b';
 }
 
 .simple-memory-icon-stealth_fill:before {
-    content: "\e72c";
+    content: '\e72c';
 }
 
 .simple-memory-icon-tasklist_fill:before {
-    content: "\e733";
+    content: '\e733';
 }
 
 .simple-memory-icon-trash_fill:before {
-    content: "\e738";
+    content: '\e738';
 }
 
 .simple-memory-icon-video_fill:before {
-    content: "\e73c";
+    content: '\e73c';
 }
 
 .simple-memory-icon-warning_fill:before {
-    content: "\e73d";
+    content: '\e73d';
 }
 
 .simple-memory-icon-searchfill:before {
-    content: "\e742";
+    content: '\e742';
 }
 
 .simple-memory-icon-financial_fill:before {
-    content: "\e74c";
+    content: '\e74c';
 }
 
 .simple-memory-icon-int:before {
-    content: "\e763";
+    content: '\e763';
 }
 
 .simple-memory-icon-lighting:before {
-    content: "\e622";
+    content: '\e622';
 }
 
 .simple-memory-icon-shandian:before {
-    content: "\e618";
+    content: '\e618';
 }
 
 .simple-memory-icon-shandian2:before {
-    content: "\e70e";
+    content: '\e70e';
 }
 
 .simple-memory-icon-code1:before {
-    content: "\ea77";
+    content: '\ea77';
 }
 
 .simple-memory-icon-code3:before {
-    content: "\e699";
+    content: '\e699';
 }
 
 .simple-memory-icon-code4:before {
-    content: "\e654";
+    content: '\e654';
 }
 
 .simple-memory-icon-code5:before {
-    content: "\e657";
+    content: '\e657';
 }
 
 .simple-memory-icon-activity_fill:before {
-    content: "\e6de";
+    content: '\e6de';
 }
 
 .simple-memory-icon-document_fill:before {
-    content: "\e6f3";
+    content: '\e6f3';
 }
 
 .simple-memory-icon-task_fill:before {
-    content: "\e732";
+    content: '\e732';
 }
 
 .simple-memory-icon-browse_fill:before {
-    content: "\e6e4";
+    content: '\e6e4';
 }
 
 .simple-memory-icon-collection_fill:before {
-    content: "\e6ea";
+    content: '\e6ea';
 }
 
 .simple-memory-icon-label_fill:before {
-    content: "\e706";
+    content: '\e706';
 }
 
 .simple-memory-icon-like_fill:before {
-    content: "\e707";
+    content: '\e707';
 }
 
 .simple-memory-icon-praise_fill:before {
-    content: "\e71a";
+    content: '\e71a';
 }
 
 .simple-memory-icon-select_fill:before {
-    content: "\e725";
+    content: '\e725';
 }
 
 .simple-memory-icon-time_fill:before {
-    content: "\e735";
+    content: '\e735';
 }
 
 .simple-memory-icon-marketing_fill:before {
-    content: "\e74b";
+    content: '\e74b';
 }
 
 .simple-memory-icon-fuzhi:before {
-    content: "\e61b";
+    content: '\e61b';
 }
 
 .simple-memory-icon-fuzhi1:before {
-    content: "\e606";
+    content: '\e606';
 }
 
 .simple-memory-icon-icon02:before {
-    content: "\e614";
+    content: '\e614';
 }
 
 .simple-memory-icon-fuzhi2:before {
-    content: "\e6dd";
+    content: '\e6dd';
 }
 
 .simple-memory-icon-fuzhi3:before {
-    content: "\e636";
+    content: '\e636';
 }
 
 .simple-memory-icon-buzan:before {
-    content: "\e601";
+    content: '\e601';
 }
 
 .simple-memory-icon-zan1:before {
-    content: "\e610";
+    content: '\e610';
 }
 
 .simple-memory-icon-dianzan:before {
-    content: "\e616";
+    content: '\e616';
 }
 
 .simple-memory-icon-iconweiguanzhu:before {
-    content: "\e617";
+    content: '\e617';
 }
 
 .simple-memory-icon-iconyiguanzhu:before {
-    content: "\e628";
+    content: '\e628';
 }
 
 .simple-memory-icon-dianzan1:before {
-    content: "\e60a";
+    content: '\e60a';
 }
 
 .simple-memory-icon-odps-data:before {
-    content: "\e727";
+    content: '\e727';
 }
 
 .simple-memory-icon-fanhui:before {
-    content: "\e600";
+    content: '\e600';
 }
 
 .simple-memory-icon-zhiding:before {
-    content: "\e739";
+    content: '\e739';
 }
 
 .simple-memory-icon-timefill:before {
-    content: "\e65e";
+    content: '\e65e';
 }
 
 .simple-memory-icon-time:before {
-    content: "\e65f";
+    content: '\e65f';
 }
 
 .simple-memory-icon-likefill:before {
-    content: "\e668";
+    content: '\e668';
 }
 
 .simple-memory-icon-like:before {
-    content: "\e669";
+    content: '\e669';
 }
 
 .simple-memory-icon-tagfill:before {
-    content: "\e751";
+    content: '\e751';
 }
 
 .simple-memory-icon-tag:before {
-    content: "\e752";
+    content: '\e752';
 }


### PR DESCRIPTION
1. 修复拓展图标展示异常
3. 默认拓展图标font-family为iconfont，不可进行修改
4. 删除拓展图标中的iconfont的css类
<img width="803" alt="image" src="https://github.com/BNDong/Cnblogs-Theme-SimpleMemory/assets/36377605/22f8dd54-eb23-44fd-8e4d-8b249a5ccd4c">
