### PR TITLE
文章目录分级标题滚动无法高亮问题

### DIFF
--- a/src/components/articleDirectory/articleDirectory.js
+++ b/src/components/articleDirectory/articleDirectory.js
@@ -79,12 +79,23 @@ export default function main(_) {
         postBody.append(dirHtml);
 
         // 锚点监听
-        body.attr('data-bs-spy', 'scroll');
-        body.attr('data-bs-target', '#articleDirectory');
-        body.attr('data-bs-offset', '0');
-        body.attr('tabindex', '0');
-        body.scrollspy({ target: '#articleDirectory' });
+        // body.attr('data-bs-spy', 'scroll');
+        // body.attr('data-bs-target', '#articleDirectory');
+        // body.attr('data-bs-offset', '0');
+        // body.attr('tabindex', '0');
+        // body.scrollspy({ target: '#articleDirectory' });
 
+        // 锚点监听
+        setTimeout(() => {
+            const scrollSpy = new bootstrap.ScrollSpy(
+                document.documentElement,
+                {
+                    target: '#articleDirectory',
+                    offset: 80
+                }
+            );
+            scrollSpy.refresh();
+        }, 0);
 
         // 判断是否显示横向滚动条
         if (!_.__config.articleDirectory.autoWidthScroll) {


### PR DESCRIPTION
你好，我在使用 v2.1.7 版本时，发现文章目录的分级标题无法根据滚动位置自动高亮。我尝试调整了相关代码来解决这一问题。